### PR TITLE
Added port as user input, removed nano/micro sec percision from appctl list

### DIFF
--- a/cmd/appDelete.go
+++ b/cmd/appDelete.go
@@ -70,7 +70,7 @@ func appCmdDeleteRun(cmd *cobra.Command, args []string) {
 			// To delete app if Yes
 			if deleteApp == "y" {
 				// Validate app name.
-				if !constants.RegexValidate(AppNameDelete) {
+				if !constants.RegexValidate(AppNameDelete, constants.ValidAppNameRegex) {
 					fmt.Printf("Invalid App name.\n")
 					return
 				}
@@ -90,7 +90,7 @@ func appCmdDeleteRun(cmd *cobra.Command, args []string) {
 		}
 	} else {
 		// Validate app name.
-		if !constants.RegexValidate(AppNameDelete) {
+		if !constants.RegexValidate(AppNameDelete, constants.ValidAppNameRegex) {
 			fmt.Printf("Invalid App name.\n")
 			return
 		}

--- a/cmd/appDeploy.go
+++ b/cmd/appDeploy.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/platform9/appctl/pkg/appManageAPI"
@@ -66,7 +67,7 @@ func appCmdDeployRun(cmd *cobra.Command, args []string) {
 	}
 
 	// Validate app name.
-	if !constants.RegexValidate(deployApp.Name) {
+	if !constants.RegexValidate(deployApp.Name, constants.ValidAppNameRegex) {
 		fmt.Printf("Invalid App name.\n")
 		fmt.Printf("Name of the app to be deployed must contain a lowercase alphanumeric characters, '-' or '.'\nand must start with alphanumeric characters only.\n")
 		return
@@ -77,6 +78,22 @@ func appCmdDeployRun(cmd *cobra.Command, args []string) {
 		appSourceImage, _ := reader.ReadString('\n')
 		deployApp.Image = strings.TrimSuffix(appSourceImage, "\n")
 		deployApp.Image = strings.TrimSuffix(deployApp.Image, "\t")
+	}
+
+	if deployApp.Port == "" {
+		fmt.Printf("Port [8080]: ")
+		port, _ := reader.ReadString('\n')
+		deployApp.Port = strings.TrimSuffix(port, "\n")
+		deployApp.Port = strings.TrimSuffix(deployApp.Port, "\t")
+	}
+
+	if deployApp.Port != "" {
+		// Check if port given is valid i.e numeric only.
+		_, err := strconv.Atoi(deployApp.Port)
+		if err != nil {
+			fmt.Printf("Invalid Port. Please enter a valid port\n")
+			return
+		}
 	}
 
 	errapi := appManageAPI.CreateApp(deployApp.Name, deployApp.Image, deployApp.Env, deployApp.Port)

--- a/cmd/appDescribe.go
+++ b/cmd/appDescribe.go
@@ -40,7 +40,7 @@ func appCmdDescribeRun(cmd *cobra.Command, args []string) {
 	}
 
 	// Validate app name.
-	if !constants.RegexValidate(AppName) {
+	if !constants.RegexValidate(AppName, constants.ValidAppNameRegex) {
 		fmt.Printf("Invalid App name.\n")
 		return
 	}

--- a/pkg/appManageAPI/appManageAPI.go
+++ b/pkg/appManageAPI/appManageAPI.go
@@ -740,7 +740,9 @@ func appCreationTime(appCreationTime string) string {
 		return appCreationTime
 	}
 	currentTime := time.Now()
-	return currentTime.Sub(appCreatedTimeParsed).String()
+	appCreateTime := currentTime.Sub(appCreatedTimeParsed).String()
+	// Consider only seconds, exclude micro/nano seconds.
+	return fmt.Sprintf("%ss", strings.Split(appCreateTime, ".")[0])
 }
 
 //Get the response message for deployed apps.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 )
 
+// API Variables.
 var (
 	APPURL               = "http://fastpath.appctl.net:6112/v1/apps"
 	TABLEFORMAT          = "NAME | URL | IMAGE | READY | CREATIONTIME | REASON"
@@ -14,9 +15,7 @@ var (
 	CLIENTID             = "37cBgJP3K2yiYq2gamzEv1sH7vN2x6Z1"
 	DEVICEREQUESTPAYLOAD = "client_id=" + CLIENTID + "&scope=" + GetAllScope()
 	// Grant type is urlencoded
-	GrantType              = "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code"
-	InvalidImage           = "Unable to fetch image"
-	MaxAppDeployLimitError = "Maximum apps deploy limit reached!!"
+	GrantType = "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code"
 )
 
 type ListAppInfo struct {
@@ -85,23 +84,25 @@ func GetAllScope() string {
 
 var (
 	// Valid App Name to deploy.
-	VALIDREGEX = fmt.Sprintf(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
+	ValidAppNameRegex = fmt.Sprintf(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
 )
 
 // Validate a regex.
-func RegexValidate(name string) bool {
-	Regex := regexp.MustCompile(VALIDREGEX)
+func RegexValidate(name string, regex string) bool {
+	Regex := regexp.MustCompile(regex)
 	return Regex.MatchString(name)
 }
 
 // Error Messages.
 var (
-	ConnectionRefused    = "connection refused"
-	NetworkUnReachable   = "Network is unreachable"
-	InternetConnectivity = "Please check your internet connectivity and try again."
-	BackendServerDown    = "Backend server is down. Please try later!!"
-	AccessForbidden      = "Access Forbidden."
-	MaxAppDeployLimit    = "Maximum apps deploy limit reached!!"
+	ConnectionRefused      = "connection refused"
+	NetworkUnReachable     = "Network is unreachable"
+	InternetConnectivity   = "Please check your internet connectivity and try again."
+	BackendServerDown      = "Backend server is down. Please try later!!"
+	AccessForbidden        = "Access Forbidden."
+	MaxAppDeployLimit      = "Maximum apps deploy limit reached!!"
+	InvalidImage           = "Unable to fetch image"
+	MaxAppDeployLimitError = "Maximum apps deploy limit reached!!"
 )
 
 const (


### PR DESCRIPTION
* Added port as user input in port flag is not set.
Mac:

![Screenshot 2021-12-28 at 9 32 38 AM](https://user-images.githubusercontent.com/77390180/147528332-838768ab-0809-4788-91ca-6c20c9868f51.png)

![Screenshot 2021-12-28 at 9 35 58 AM](https://user-images.githubusercontent.com/77390180/147528242-d20e4008-1dd8-45c3-8166-000d9308f803.png)

**Ubuntu:**
![Screenshot 2021-12-28 at 9 46 46 AM](https://user-images.githubusercontent.com/77390180/147528259-4109f255-d9f0-4b57-89e4-e107790d1c82.png)

![Screenshot 2021-12-28 at 9 47 43 AM](https://user-images.githubusercontent.com/77390180/147528592-7a5d17c0-f991-4edb-9313-b60fe34f0b1a.png)



* Simple validation of port if its numeric or not.

![Screenshot 2021-12-28 at 10 04 26 AM](https://user-images.githubusercontent.com/77390180/147528497-ac726829-cdf9-4858-b86f-62227f9370ab.png)

* Modified regexFunction to generalise and accept name, respective regex. 

* Removed the nano/micro level percision in app creation time in appctl list to make more user readable. 
