### PR TITLE
Input reading for windows, trim \r along with \n.

### DIFF
--- a/cmd/appDelete.go
+++ b/cmd/appDelete.go
@@ -61,6 +61,7 @@ func appCmdDeleteRun(cmd *cobra.Command, args []string) {
 			fmt.Printf("Are you sure you want to delete app (y/n)? ")
 			deleteApp, _ = reader.ReadString('\n')
 			deleteApp = strings.TrimSuffix(deleteApp, "\n")
+			deleteApp = strings.TrimSuffix(deleteApp, "\r")
 
 			// If response is other than "y" or "n"
 			if deleteApp != "y" && deleteApp != "n" {

--- a/cmd/appDeploy.go
+++ b/cmd/appDeploy.go
@@ -63,7 +63,7 @@ func appCmdDeployRun(cmd *cobra.Command, args []string) {
 		fmt.Printf("App Name: ")
 		appName, _ := reader.ReadString('\n')
 		deployApp.Name = strings.TrimSuffix(appName, "\n")
-		deployApp.Name = strings.TrimSuffix(deployApp.Name, "\t")
+		deployApp.Name = strings.TrimSuffix(deployApp.Name, "\r")
 	}
 
 	// Validate app name.
@@ -77,14 +77,14 @@ func appCmdDeployRun(cmd *cobra.Command, args []string) {
 		fmt.Printf("Source Image: ")
 		appSourceImage, _ := reader.ReadString('\n')
 		deployApp.Image = strings.TrimSuffix(appSourceImage, "\n")
-		deployApp.Image = strings.TrimSuffix(deployApp.Image, "\t")
+		deployApp.Image = strings.TrimSuffix(deployApp.Image, "\r")
 	}
 
 	if deployApp.Port == "" {
 		fmt.Printf("Port [8080]: ")
 		port, _ := reader.ReadString('\n')
 		deployApp.Port = strings.TrimSuffix(port, "\n")
-		deployApp.Port = strings.TrimSuffix(deployApp.Port, "\t")
+		deployApp.Port = strings.TrimSuffix(deployApp.Port, "\r")
 	}
 
 	if deployApp.Port != "" {


### PR DESCRIPTION
* In Windows Case - Hitting Enter while reading input app name, image (appctl deploy, appctl delete) will take "\r\n", where as 
In MacOs, Linux - "\n" will be taken. 

After trim "\r" along with "\n"
![Screenshot (15)](https://user-images.githubusercontent.com/77390180/147880507-00513c35-23fd-49d7-baa6-4fbb2099d172.png)

