### PR TITLE
Error sending segment information due to certificate verification failure GROW-78

### DIFF
--- a/pkg/segment/segment.go
+++ b/pkg/segment/segment.go
@@ -16,6 +16,7 @@ func SegmentClient() (analytics.Client, error) {
 	logger.SetOutput(io.Discard)
 	client, err := analytics.NewWithConfig(APPCTL_SEGMENT_WRITE_KEY, analytics.Config{
 		Logger: analytics.StdLogger(logger),
+		// TODO: Possibly have custom callbacks and redirect logs to some file
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- now redirecting all error messages from `analytics` package to `io.Discard`.
This solution simply discards all the log messages from the `analytics` package.

<img width="935" alt="Screenshot 2022-02-01 at 14 12 52" src="https://user-images.githubusercontent.com/39493074/151937366-b0af0162-313c-44c1-bcf6-2d7e2406382f.png">
The first call to `appctl list` shows the current release and the second one is the current change.