### PR TITLE
Fixed a typo in appctl deploy example

### DIFF
--- a/cmd/appDeploy.go
+++ b/cmd/appDeploy.go
@@ -34,8 +34,8 @@ var deployExample = `
   	  appctl deploy -n <appname> -i gcr.io/<GCP_projectID>/<image> -u oauth2accesstoken -P <Token obtained from gcloud CLI>
 	
 	  # Sample command to deploy an app from an ACR private registry path
-	  # Service principal should have role Reader to pull the image
-  	  appctl deploy -n <appname> -i <registry name>.azurecr.io/<image>:<tag> -u <service principle appId> -P <service principle password>
+	  # Service principal should have role "Reader" to pull the image
+	  appctl deploy -n <appname> -i <registry name>.azurecr.io/<image>:<tag> -u <service principal appId> -P <service principal password>
 
 
   # Deploy an app using app-name and container image, and pass environment variables.


### PR DESCRIPTION
## ISSUE(S):
Fixed typo in azure service principal deploy example.

##### Testing Output (Snapshot/file)
![Screenshot 2022-03-07 at 12 05 27 PM](https://user-images.githubusercontent.com/2087935/156980414-73aba904-8016-4574-b3df-4cdbd353e7fd.png)


